### PR TITLE
Correct success return value for `VALGRIND_MAKE_MEM_UNDEFINED`

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -760,7 +760,7 @@ pub mod memcheck {
                 raw_call!(mc_make_mem_defined_if_addressable, addr, len)
             }
         };
-        if ret == 0 {
+        if ret == -1 {
             Ok(())
         } else {
             Err(Error::NoValgrind)


### PR DESCRIPTION
According to the valgrind docs (and implementation) these "return -1, when run on Valgrind and 0 otherwise."

fixes #5 