### PR TITLE
Fix `opt-out` runtime crash, allow `mark_memory` outside Valgrind

### DIFF
--- a/src/requests/constants.rs
+++ b/src/requests/constants.rs
@@ -8,6 +8,7 @@ pub mod memcheck {
     // vg-docs/mc-manual.clientreqs:
     // "They return -1, when run on Valgrind and 0 otherwise."
     pub const MAKE_MEM_OK: usize = usize::MAX;
+    pub const MAKE_MEM_NO_VALGRIND: usize = 0;
 
     // vg-docs/mc-manual.clientreqs:
     // "... returns zero if the relevant property holds;

--- a/src/requests/constants.rs
+++ b/src/requests/constants.rs
@@ -8,7 +8,6 @@ pub mod memcheck {
     // vg-docs/mc-manual.clientreqs:
     // "They return -1, when run on Valgrind and 0 otherwise."
     pub const MAKE_MEM_OK: usize = usize::MAX;
-    pub const MAKE_MEM_NO_VALGRIND: usize = 0;
 
     // vg-docs/mc-manual.clientreqs:
     // "... returns zero if the relevant property holds;

--- a/src/requests/memcheck.rs
+++ b/src/requests/memcheck.rs
@@ -138,7 +138,7 @@ pub fn mark_memory(
 ) -> Result<(), UnaddressableBytes> {
     macro_rules! r {
         ($req:path) => {
-            client_request!($req, addr, size)
+            client_request!($req, MAKE_MEM_OK, addr, size, 0, 0, 0)
         };
     }
 
@@ -149,10 +149,7 @@ pub fn mark_memory(
         MemState::DefinedIfAddressable => r!(CR::CG_VALGRIND_MAKE_MEM_DEFINED_IF_ADDRESSABLE),
     };
 
-    match result {
-        MAKE_MEM_OK | MAKE_MEM_NO_VALGRIND => Ok(()),
-        unaddressable => Err(unaddressable),
-    }
+    (result == MAKE_MEM_OK).then_some(()).ok_or(result)
 }
 
 macro_rules! check_mem {

--- a/src/requests/memcheck.rs
+++ b/src/requests/memcheck.rs
@@ -149,7 +149,10 @@ pub fn mark_memory(
         MemState::DefinedIfAddressable => r!(CR::CG_VALGRIND_MAKE_MEM_DEFINED_IF_ADDRESSABLE),
     };
 
-    (result == MAKE_MEM_OK).then_some(()).ok_or(result)
+    match result {
+        MAKE_MEM_OK | MAKE_MEM_NO_VALGRIND => Ok(()),
+        unaddressable => Err(unaddressable),
+    }
 }
 
 macro_rules! check_mem {

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -17,6 +17,7 @@ macro_rules! client_request {
         ($($arg as usize),*).0
     }};
     ($request:path, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {{
+        #[cfg(not(feature = "opt-out"))]
         $crate::requests::assert_defined!($request);
         client_request!(^ 0, $request, $arg1, $arg2, $arg3, $arg4, $arg5)
     }};
@@ -39,6 +40,7 @@ macro_rules! client_request {
 
 // Asserts that a client request is supported by the Valgrind version this crate was compiled against.
 // These assertions are expected to be optimized out by the compiler for supported requests.
+#[cfg(not(feature = "opt-out"))]
 macro_rules! assert_defined {
     ($request:path) => {{
         const REQUIREMENT: u32 = $request.required_version();
@@ -70,7 +72,9 @@ macro_rules! assert_defined {
     }};
 }
 
-pub(crate) use {assert_defined, client_request};
+#[cfg(not(feature = "opt-out"))]
+pub(crate) use assert_defined;
+pub(crate) use client_request;
 
 #[doc = include_str!("../../doc/println.md")]
 #[macro_export]

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -9,18 +9,28 @@ pub mod valgrind;
 pub(crate) mod constants;
 
 macro_rules! client_request {
-    (^ $($arg:expr),*) =>  {{
+    (^ $default:expr, $request:path, $($arg:expr),*) =>  {{
         #[cfg(not(feature = "opt-out"))]
-        unsafe { $crate::bindings::valgrind_client_request_expr($($arg as usize),*) }
+        {
+            $crate::requests::assert_defined!($request);
+            unsafe {
+                $crate::bindings::valgrind_client_request_expr(
+                    $default as usize,
+                    $request as usize,
+                    $($arg as usize),*
+                )
+            }
+        }
 
         #[cfg(feature = "opt-out")]
-        ($($arg as usize),*).0
+        $default
     }};
-    ($request:path, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {{
-        #[cfg(not(feature = "opt-out"))]
-        $crate::requests::assert_defined!($request);
-        client_request!(^ 0, $request, $arg1, $arg2, $arg3, $arg4, $arg5)
-    }};
+    ($request:path, $default:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+        client_request!(^ $default, $request, $arg1, $arg2, $arg3, $arg4, $arg5)
+    };
+    ($request:path, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
+        client_request!($request, 0, $arg1, $arg2, $arg3, $arg4, $arg5)
+    };
     ($request:path, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr) => {
         client_request!($request, $arg1, $arg2, $arg3, $arg4, 0)
     };
@@ -40,14 +50,14 @@ macro_rules! client_request {
 
 // Asserts that a client request is supported by the Valgrind version this crate was compiled against.
 // These assertions are expected to be optimized out by the compiler for supported requests.
-#[cfg(not(feature = "opt-out"))]
 macro_rules! assert_defined {
     ($request:path) => {{
         const REQUIREMENT: u32 = $request.required_version();
         const SYS_VERSION: u32 = crate::VALGRIND_VERSION.0 * 100 + crate::VALGRIND_VERSION.1;
 
-        // check Valgrind headers indeed found 
-        assert_ne!(0, SYS_VERSION,
+        // check Valgrind headers indeed found
+        assert_ne!(
+            0, SYS_VERSION,
             "\n`bindgen(libclang)` failed to locate `<valgrind/valgrind.h>`.\n\
             \tThis typically means Valgrind headers ain't found on the standard include paths:\n\
             \t\t<sysroot>/usr/include\n\
@@ -55,7 +65,8 @@ macro_rules! assert_defined {
             \t\t...\n\
             \t\t\tnor via 'pkg-config' probe.\n\
             \tYou might try 'VALGRIND_INCLUDE=<path to valgrind/include>' as a quick workaround.\n\
-            \tBuild configuration doc: https://docs.rs/crabgrind#build-configuration");
+            \tBuild configuration doc: https://docs.rs/crabgrind#build-configuration"
+        );
 
         // check request requirement matches local Valgrind version
         assert!(
@@ -72,7 +83,6 @@ macro_rules! assert_defined {
     }};
 }
 
-#[cfg(not(feature = "opt-out"))]
 pub(crate) use assert_defined;
 pub(crate) use client_request;
 

--- a/tests/memcheck.rs
+++ b/tests/memcheck.rs
@@ -87,6 +87,12 @@ fn count_leak_blocks() {
 }
 
 #[test]
+fn mark_memory_no_valgrind() {
+    let res = mc::mark_memory(std::ptr::null(), 1, mc::MemState::Undefined);
+    assert_eq!(res, Ok(()));
+}
+
+#[test]
 fn mark_memory_defined() {
     valgrind!(memcheck => {
         const N:usize = 5;


### PR DESCRIPTION
Two commits here:

1. Disables the `assert_defined!` check when "opt-out" is enabled, which prevents runtime panics due to missing Valgrind headers.

2. Allow `mark_memory` to succeed when not running under Valgrind. Seems fair for this to be a no-op when there's nothing actually doing the marking. Without this, enabling "opt-out" makes all `mark_memory` calls error.
