### PR TITLE
Replace `opt-out` feature with proper stubs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,17 @@ exclude = [".gitignore", "Justfile", "Cross.toml", "rustfmt.toml", "rust-toolcha
 			"*.sh", "*.py", "*.defs", "*.head", "*.dict", "*.json", "tests/*"]
 
 [features]
-default = []
-# Turns every request into no-op.
+default = ["valgrind"]
+# Enables execution of client requests.
+# When disabled, all requests are no-ops and no native build steps or build dependencies are used.
+valgrind = ["dep:cc", "dep:bindgen", "dep:pkg-config"]
+# `opt-out` was removed (v0.3). Use `default-features = false`.
 opt-out = []
 
 [build-dependencies]
-cc = "1"
-bindgen = "0.72"
-pkg-config = "0.3"
+cc = { version = "1", optional = true }
+bindgen = { version = "0.72", optional = true }
+pkg-config = { version = "0.3", optional = true }
 
 [dev-dependencies]
 regex = "1"

--- a/Justfile
+++ b/Justfile
@@ -4,14 +4,14 @@ default:
 
 # Build library and integration tests
 build: check doc
+	cargo build
 	cargo build --no-default-features
-	cargo build --all-features
 	cargo test --release --no-run 
 
 # Run linter
 check: cspell mdlint
+	cargo clippy
 	cargo clippy --no-default-features
-	cargo clippy --all-features
 
 # Spell check
 cspell:
@@ -36,6 +36,7 @@ doc:
 # Test integration and documentation
 test: check test-doc
 	cargo test --release
+	cargo test --release --no-default-features
 
 # Test doc examples
 test-doc:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First, add `crabgrind` as a dependency in `Cargo.toml`
 
 ```toml
 [dependencies]
-crabgrind = "0.2"
+crabgrind = "0.3"
 ```
 
 or
@@ -81,12 +81,19 @@ And run under Valgrind
 
 ## Features
 
-If you need your builds to be free of Valgrind artifacts, enable the `opt-out`
-feature. This turns every request into no-op.
+- **valgrind** *(default)* Enables execution of requests, C-shim compilation and
+  bindings generation.
 
-> ```toml
-> crabgrind = { version = "0.2", features = ["opt-out"] }
-> ```
+With `default-features = false`, all requests turn into no-op stubs and are
+optimized out by the compiler. No build dependencies are pulled in.
+
+```toml
+[dependencies]
+crabgrind = { version = "0.3", default-features = false }
+
+[build-dependencies]
+crabgrind = "0.3"
+```
 
 ## More Examples
 

--- a/build.rs
+++ b/build.rs
@@ -1,81 +1,94 @@
 //! Build script for native library wrapping the Valgrind [Client Request API](https://valgrind.org/docs/manual/manual-core-adv.html#manual-core-adv.clientreq)
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
 
-const ENV_VALGRIND_INCLUDE: &str = "VALGRIND_INCLUDE";
+#[cfg(feature = "valgrind")]
+mod imp {
+    use std::{
+        env,
+        path::{Path, PathBuf},
+    };
 
-fn env_include() -> Option<PathBuf> {
-    let Ok(path) = env::var(ENV_VALGRIND_INCLUDE).map(PathBuf::from) else { return None };
-    assert!(path.exists(), "{ENV_VALGRIND_INCLUDE}={} Path does not exists", path.display());
-    Some(path)
-}
+    const ENV_VALGRIND_INCLUDE: &str = "VALGRIND_INCLUDE";
 
-fn pkgconfig_include() -> Option<Vec<PathBuf>> {
-    pkg_config::Config::new()
-        .cargo_metadata(false)
-        .env_metadata(false)
-        .print_system_libs(false)
-        .print_system_cflags(true)
-        .probe("valgrind")
-        .ok()
-        .map(|lib| {
-            lib.include_paths
-                .into_iter()
-                .map(|path| path.parent().map(Path::to_path_buf).unwrap_or(path))
-                .collect()
-        })
-}
-
-fn valgrind_include_paths() -> Vec<PathBuf> {
-    env_include().map(|p| vec![p]).or_else(pkgconfig_include).unwrap_or_default()
-}
-
-fn build_native(valgrind_include: &[PathBuf]) {
-    let mut builder = cc::Build::new();
-
-    for path in valgrind_include {
-        builder.include(path);
+    fn env_include() -> Option<PathBuf> {
+        let Ok(path) = env::var(ENV_VALGRIND_INCLUDE).map(PathBuf::from) else { return None };
+        assert!(path.exists(), "{ENV_VALGRIND_INCLUDE}={} Path does not exists", path.display());
+        Some(path)
     }
 
-    builder.flag("-idiraftervalgrind/include").file("valgrind/native.c").compile("native");
+    fn pkgconfig_include() -> Option<Vec<PathBuf>> {
+        pkg_config::Config::new()
+            .cargo_metadata(false)
+            .env_metadata(false)
+            .print_system_libs(false)
+            .print_system_cflags(true)
+            .probe("valgrind")
+            .ok()
+            .map(|lib| {
+                lib.include_paths
+                    .into_iter()
+                    .map(|path| path.parent().map(Path::to_path_buf).unwrap_or(path))
+                    .collect()
+            })
+    }
+
+    fn valgrind_include_paths() -> Vec<PathBuf> {
+        env_include().map(|p| vec![p]).or_else(pkgconfig_include).unwrap_or_default()
+    }
+
+    fn build_native(valgrind_include: &[PathBuf]) {
+        let mut builder = cc::Build::new();
+
+        for path in valgrind_include {
+            builder.include(path);
+        }
+
+        builder.flag("-idiraftervalgrind/include").file("valgrind/native.c").compile("native");
+    }
+
+    fn gen_bindings(include: &[PathBuf]) {
+        let bindings = include
+            .iter()
+            .fold(bindgen::builder(), |b, path| b.clang_arg(format!("-iquote{}", path.display())))
+            .clang_arg("-idiraftervalgrind/include")
+            .allowlist_var("__VALGRIND_MAJOR__")
+            .allowlist_var("__VALGRIND_MINOR__")
+            .allowlist_type("CG_.*ClientRequest")
+            .rustified_enum("CG_.*ClientRequest")
+            .raw_line(std::fs::read_to_string("valgrind/valgrind_version.rs").unwrap_or_else(
+                |_| panic!("valgrind/valgrind_version.rs should exists. 'Use: just --list'"),
+            ))
+            .layout_tests(false)
+            .use_core()
+            .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+            .header("valgrind/wrapper.h")
+            .generate()
+            .expect("`bindgen` bindings generation failed");
+
+        let out_dir = env::var("OUT_DIR").map(PathBuf::from).unwrap();
+        let path = out_dir.join("bindings.rs");
+
+        bindings.write_to_file(path).unwrap();
+    }
+
+    pub fn main() {
+        println!("cargo:rerun-if-changed=valgrind/wrapper.h");
+        println!("cargo:rerun-if-changed=valgrind/valgrind_version.rs");
+        println!("cargo:rerun-if-changed=valgrind/native.c");
+        println!("cargo:rerun-if-env-changed={ENV_VALGRIND_INCLUDE}");
+        println!("cargo:rerun-if-env-changed=TARGET");
+
+        let include = valgrind_include_paths();
+
+        build_native(&include);
+        gen_bindings(&include);
+    }
 }
 
-fn gen_bindings(include: &[PathBuf]) {
-    let bindings = include
-        .iter()
-        .fold(bindgen::builder(), |b, path| b.clang_arg(format!("-iquote{}", path.display())))
-        .clang_arg("-idiraftervalgrind/include")
-        .allowlist_var("__VALGRIND_MAJOR__")
-        .allowlist_var("__VALGRIND_MINOR__")
-        .allowlist_type("CG_.*ClientRequest")
-        .rustified_enum("CG_.*ClientRequest")
-        .raw_line(std::fs::read_to_string("valgrind/valgrind_version.rs").unwrap_or_else(|_| {
-            panic!("valgrind/valgrind_version.rs should exists. 'Use: just --list'")
-        }))
-        .layout_tests(false)
-        .use_core()
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
-        .header("valgrind/wrapper.h")
-        .generate()
-        .expect("`bindgen` bindings generation failed");
-
-    let out_dir = env::var("OUT_DIR").map(PathBuf::from).unwrap();
-    let path = out_dir.join("bindings.rs");
-
-    bindings.write_to_file(path).unwrap();
+#[cfg(not(feature = "valgrind"))]
+mod imp {
+    pub fn main() {}
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=valgrind/wrapper.h");
-    println!("cargo:rerun-if-changed=valgrind/valgrind_version.rs");
-    println!("cargo:rerun-if-changed=valgrind/native.c");
-    println!("cargo:rerun-if-env-changed={ENV_VALGRIND_INCLUDE}");
-    println!("cargo:rerun-if-env-changed=TARGET");
-
-    let include = valgrind_include_paths();
-
-    build_native(&include);
-    gen_bindings(&include);
+    imp::main();
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 #![allow(non_camel_case_types)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::match_same_arms)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,23 +1,71 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![cfg_attr(not(feature = "valgrind"), allow(unused, missing_docs, clippy::needless_pass_by_value))]
 #![no_std]
 
+#[cfg(feature = "opt-out")]
+compile_error!("`opt-out` was removed (v0.3). Use `default-features = false`.");
+
+#[cfg(feature = "valgrind")]
 mod bindings;
 mod requests;
 pub use requests::{ScopeGuard, cachegrind, callgrind, dhat, drd, helgrind, memcheck, valgrind};
 
 /// Valgrind version this crate was compiled against.
-pub const VALGRIND_VERSION: (u32, u32) =
-    (bindings::__VALGRIND_MAJOR__, bindings::__VALGRIND_MINOR__);
+pub const VALGRIND_VERSION: (u32, u32) = imp::VALGRIND_VERSION;
 
 #[doc(hidden)]
-#[inline(always)]
-pub fn __print(t: impl AsRef<core::ffi::CStr>) {
-    unsafe { bindings::vg_print(t.as_ref().as_ptr()) };
+#[cfg(feature = "valgrind")]
+pub mod imp {
+    pub const VALGRIND_VERSION: (u32, u32) =
+        (super::bindings::__VALGRIND_MAJOR__, super::bindings::__VALGRIND_MINOR__);
+
+    #[doc = include_str!("../doc/println.md")]
+    #[macro_export]
+    macro_rules! println{
+        ($($arg:tt)+) => {{
+            let msg = format!("{}\n\0", format_args!($($arg)+));
+
+            let msg = unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(msg.as_bytes()) };
+            $crate::imp::__print(msg);
+        }}
+    }
+
+    #[doc = include_str!("../doc/println_stacktrace.md")]
+    #[macro_export]
+    macro_rules! print_stacktrace{
+        ($($arg:tt)+) => {{
+            let msg = format!("{}\0", format_args!($($arg)+));
+
+            let msg = unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(msg.as_bytes()) };
+            $crate::imp::__print_stacktrace(msg);
+        }}
+    }
+
+    #[inline(always)]
+    pub fn __print(t: impl AsRef<core::ffi::CStr>) {
+        unsafe { super::bindings::vg_print(t.as_ref().as_ptr()) };
+    }
+
+    #[inline(always)]
+    pub fn __print_stacktrace(t: impl AsRef<core::ffi::CStr>) {
+        unsafe { super::bindings::vg_print_backtrace(t.as_ref().as_ptr()) };
+    }
 }
 
-#[doc(hidden)]
-#[inline(always)]
-pub fn __print_stacktrace(t: impl AsRef<core::ffi::CStr>) {
-    unsafe { bindings::vg_print_backtrace(t.as_ref().as_ptr()) };
+#[cfg(not(feature = "valgrind"))]
+mod imp {
+    pub const VALGRIND_VERSION: (u32, u32) = (0, 0);
+
+    #[doc = include_str!("../doc/println.md")]
+    #[macro_export]
+    macro_rules! println {
+        ($($arg:tt)+) => {};
+    }
+
+    #[doc = include_str!("../doc/println_stacktrace.md")]
+    #[macro_export]
+    macro_rules! print_stacktrace {
+        ($($arg:tt)+) => {};
+    }
 }

--- a/src/requests/cachegrind.rs
+++ b/src/requests/cachegrind.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../../doc/cachegrind.md")]
 use super::client_request;
+
+#[cfg(feature = "valgrind")]
 use crate::bindings::CG_CachegrindClientRequest as CR;
 
 #[doc = include_str!("../../doc/cachegrind/start_instrumentation.md")]

--- a/src/requests/callgrind.rs
+++ b/src/requests/callgrind.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../../doc/callgrind.md")]
 use super::client_request;
+
+#[cfg(feature = "valgrind")]
 use crate::bindings::CG_CallgrindClientRequest as CR;
 
 use core::ffi::CStr;

--- a/src/requests/dhat.rs
+++ b/src/requests/dhat.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!("../../doc/dhat.md")]
 use super::{client_request, constants::dhat::AD_HOC_EVENT_DEFAULT_WEIGHT};
+
+#[cfg(feature = "valgrind")]
 use crate::bindings::CG_DHATClientRequest as CR;
+
 use core::ffi::c_void;
 
 #[doc = include_str!("../../doc/dhat/ad_hoc_event.md")]

--- a/src/requests/drd.rs
+++ b/src/requests/drd.rs
@@ -1,9 +1,9 @@
 #![doc = include_str!("../../doc/drd.md")]
 use super::{client_request, valgrind::ThreadId};
-use crate::{
-    bindings::CG_DRDClientRequest as CR,
-    requests::{Scope, ScopeGuard, sealed::Sealed},
-};
+use crate::requests::{Scope, ScopeGuard, sealed::Sealed};
+
+#[cfg(feature = "valgrind")]
+use crate::bindings::CG_DRDClientRequest as CR;
 
 use core::{
     ffi::{CStr, c_char, c_void},

--- a/src/requests/helgrind.rs
+++ b/src/requests/helgrind.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!("../../doc/helgrind.md")]
 use super::client_request;
+
+#[cfg(feature = "valgrind")]
 use crate::bindings::CG_HelgrindClientRequest as CR;
 
 use core::ffi::c_void;

--- a/src/requests/memcheck.rs
+++ b/src/requests/memcheck.rs
@@ -2,13 +2,15 @@
 use super::{client_request, constants::memcheck::*};
 use crate::{
     ScopeGuard,
-    bindings::CG_MemcheckClientRequest as CR,
     requests::{Scope, sealed::Sealed},
 };
 use core::{
     ffi::{CStr, c_void},
     marker::PhantomData,
 };
+
+#[cfg(feature = "valgrind")]
+use crate::bindings::CG_MemcheckClientRequest as CR;
 
 /// Identifier for a custom memory block description.
 ///
@@ -131,17 +133,13 @@ pub enum VBitsError {
     Unknown(u8),
 }
 
-#[cfg(feature = "opt-out")]
 #[doc = include_str!("../../doc/memcheck/mark_memory.md")]
-#[inline(always)]
-pub fn mark_memory(_addr: *const c_void, _size: usize, _mark: MemState) -> Result<(), NoValgrind> {
-    Ok(())
-}
-
-#[cfg(not(feature = "opt-out"))]
-#[doc = include_str!("../../doc/memcheck/mark_memory.md")]
+#[allow(clippy::match_same_arms)]
 #[inline(always)]
 pub fn mark_memory(addr: *const c_void, size: usize, mark: MemState) -> Result<(), NoValgrind> {
+    #[cfg(not(feature = "valgrind"))]
+    return Ok(());
+
     macro_rules! r {
         ($req:path) => {
             client_request!($req, addr, size)
@@ -237,31 +235,21 @@ macro_rules! vbits {
     };
 }
 
-#[cfg(feature = "opt-out")]
-#[doc = include_str!("../../doc/memcheck/vbits.md")]
-#[inline(always)]
-pub fn vbits(_addr: *const c_void, _dest: &mut [u8]) -> Result<(), VBitsError> {
-    Ok(())
-}
-
-#[cfg(not(feature = "opt-out"))]
 #[doc = include_str!("../../doc/memcheck/vbits.md")]
 #[inline(always)]
 pub fn vbits(addr: *const c_void, dest: &mut [u8]) -> Result<(), VBitsError> {
+    #[cfg(not(feature = "valgrind"))]
+    return Ok(());
+
     vbits!(CR::CG_VALGRIND_GET_VBITS, addr, dest)
 }
 
-#[cfg(feature = "opt-out")]
-#[doc = include_str!("../../doc/memcheck/set_vbits.md")]
-#[inline(always)]
-pub fn set_vbits(_addr: *const c_void, _vbits: &[u8]) -> Result<(), VBitsError> {
-    Ok(())
-}
-
-#[cfg(not(feature = "opt-out"))]
 #[doc = include_str!("../../doc/memcheck/set_vbits.md")]
 #[inline(always)]
 pub fn set_vbits(addr: *const c_void, vbits: &[u8]) -> Result<(), VBitsError> {
+    #[cfg(not(feature = "valgrind"))]
+    return Ok(());
+
     vbits!(CR::CG_VALGRIND_SET_VBITS, addr, vbits)
 }
 

--- a/src/requests/mod.rs
+++ b/src/requests/mod.rs
@@ -10,19 +10,19 @@ pub(crate) mod constants;
 
 macro_rules! client_request {
     (^ $default:expr, $request:path, $($arg:expr),*) =>  {{
-        #[cfg(not(feature = "opt-out"))]
+        #[cfg(feature = "valgrind")]
         {
             $crate::requests::assert_defined!($request);
-            unsafe { 
+            unsafe {
                 $crate::bindings::valgrind_client_request_expr(
-                    $default as usize, 
-                    $request as usize, 
+                    $default as usize,
+                    $request as usize,
                     $($arg as usize),*
                 )
             }
         }
 
-        #[cfg(feature = "opt-out")]
+        #[cfg(not(feature = "valgrind"))]
         $default
     }};
     ($request:path, $default:expr, $arg1:expr, $arg2:expr, $arg3:expr, $arg4:expr, $arg5:expr) => {
@@ -85,28 +85,6 @@ macro_rules! assert_defined {
 
 pub(crate) use assert_defined;
 pub(crate) use client_request;
-
-#[doc = include_str!("../../doc/println.md")]
-#[macro_export]
-macro_rules! println{
-    ($($arg:tt)+) => {{
-        let msg = format!("{}\n\0", format_args!($($arg)+));
-
-        let msg = unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(msg.as_bytes()) };
-        $crate::__print(msg);
-    }}
-}
-
-#[doc = include_str!("../../doc/println_stacktrace.md")]
-#[macro_export]
-macro_rules! print_stacktrace{
-    ($($arg:tt)+) => {{
-        let msg = format!("{}\0", format_args!($($arg)+));
-
-        let msg = unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(msg.as_bytes()) };
-        $crate::__print_stacktrace(msg);
-    }}
-}
 
 /// Behavior for a logically scoped requests.
 pub trait Scope: sealed::Sealed {

--- a/src/requests/valgrind.rs
+++ b/src/requests/valgrind.rs
@@ -2,9 +2,11 @@
 use super::{client_request, constants::valgrind::*};
 use crate::{
     ScopeGuard,
-    bindings::CG_ValgrindClientRequest as CR,
     requests::{Scope, sealed::Sealed},
 };
+
+#[cfg(feature = "valgrind")]
+use crate::bindings::CG_ValgrindClientRequest as CR;
 
 use core::ffi::{CStr, c_int, c_void};
 
@@ -118,19 +120,13 @@ pub fn load_pdb_debuginfo(fd: RawFd, ptr: *const c_void, total_size: usize, delt
     );
 }
 
-#[cfg(feature = "opt-out")]
-#[doc = include_str!("../../doc/valgrind/map_ip_to_srcloc.md")]
-#[inline(always)]
-#[allow(clippy::needless_lifetimes)]
-pub fn map_ip_to_srcloc<'a>(_addr: *const c_void, _buf: &'a mut [u8; 64]) -> Option<&'a CStr> {
-    None
-}
-
-#[cfg(not(feature = "opt-out"))]
 #[doc = include_str!("../../doc/valgrind/map_ip_to_srcloc.md")]
 #[inline(always)]
 #[allow(clippy::needless_lifetimes)]
 pub fn map_ip_to_srcloc<'a>(addr: *const c_void, buf: &'a mut [u8; 64]) -> Option<&'a CStr> {
+    #[cfg(not(feature = "valgrind"))]
+    return None;
+
     client_request!(CR::CG_VALGRIND_MAP_IP_TO_SRCLOC, addr, buf.as_mut_ptr());
     (!is_empty_srcloc(buf)).then(|| {
         // SAFETY: Request definition guarantees the resulting buffer is a null-terminated ascii string
@@ -274,14 +270,6 @@ pub fn replaces_malloc() -> bool {
     client_request!(CR::CG_VALGRIND_REPLACES_MALLOC) != 0
 }
 
-#[cfg(feature = "opt-out")]
-#[doc = include_str!("../../doc/valgrind/toolname.md")]
-#[inline(always)]
-pub fn toolname(_buf: &mut [u8; 64]) -> Option<&CStr> {
-    None
-}
-
-#[cfg(not(feature = "opt-out"))]
 #[doc = include_str!("../../doc/valgrind/toolname.md")]
 #[inline(always)]
 pub fn toolname(buf: &mut [u8; 64]) -> Option<&CStr> {

--- a/tests/cachegrind.rs
+++ b/tests/cachegrind.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use std::process::Output;
 
 use crabgrind::cachegrind as cg;

--- a/tests/callgrind.rs
+++ b/tests/callgrind.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use crabgrind::callgrind as cg;
 
 use std::process::Output;

--- a/tests/dhat.rs
+++ b/tests/dhat.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use crabgrind::dhat as dh;
 use crabgrind::valgrind::count_errors;
 

--- a/tests/drd.rs
+++ b/tests/drd.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use crabgrind::drd as dd;
 
 use std::process::Output;

--- a/tests/helgrind.rs
+++ b/tests/helgrind.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use crabgrind::helgrind as hg;
 
 use std::process::Output;

--- a/tests/memcheck.rs
+++ b/tests/memcheck.rs
@@ -1,9 +1,9 @@
-use crabgrind::{memcheck as mc, valgrind as vg};
-
-use std::{mem::MaybeUninit, process::Output};
+#![cfg(feature = "valgrind")]
 
 mod common;
 use common::*;
+use crabgrind::{memcheck as mc, valgrind as vg};
+use std::{mem::MaybeUninit, process::Output};
 
 #[test]
 fn leak_check_quick() {

--- a/tests/stubs.rs
+++ b/tests/stubs.rs
@@ -1,0 +1,64 @@
+#![cfg(not(feature = "valgrind"))]
+
+mod common;
+use std::ffi::c_void;
+
+use common::*;
+use crabgrind::{memcheck as mc, valgrind as vg};
+
+#[test]
+fn count_errors() {
+    assert_eq!(vg::count_errors(), 0);
+}
+
+#[test]
+fn running_mode_native() {
+    assert_eq!(vg::running_mode(), vg::RunningMode::Native);
+}
+
+#[test]
+fn toolname() {
+    let mut buf = [0; 64];
+    let toolname = vg::toolname(&mut buf);
+    assert!(toolname.is_none());
+}
+
+#[test]
+fn map_ip_to_srcloc() {
+    let ip = vg::map_ip_to_srcloc as *const c_void;
+    let mut buf = [0u8; 64];
+
+    let loc = vg::map_ip_to_srcloc(ip, &mut buf);
+    assert!(loc.is_none());
+}
+
+#[test]
+fn monitor_command() {
+    assert!(vg::monitor_command(cstr!("invalid_command")).is_ok());
+}
+
+#[test]
+fn println_macro() {
+    crabgrind::println!("cg_println_msg");
+}
+
+#[test]
+fn count_leaks() {
+    mc::leak_check(mc::LeakCheck::Quick);
+    assert_eq!(mc::count_leaks(), Default::default());
+    assert_eq!(mc::count_leak_blocks(), Default::default());
+}
+
+#[test]
+fn mark_memory() {
+    let res = mc::mark_memory(std::ptr::null(), 1, mc::MemState::Undefined);
+    assert!(res.is_ok());
+}
+
+#[test]
+fn vbits() {
+    let data = [0u8; 4];
+    let mut vbits = [0u8; 4];
+
+    assert!(mc::vbits(data.as_ptr() as _, &mut vbits).is_ok());
+}

--- a/tests/valgrind.rs
+++ b/tests/valgrind.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "valgrind")]
 use crabgrind::{self as crab, valgrind as vg, valgrind::RunningMode};
 
 use std::{ffi::c_void, process::Output};


### PR DESCRIPTION
`opt-out` is supposed to provide stubs, but it still pulls in `cc`, `bindgen` and other build dependencies, runs `build.rs`, compiles the C shim, generates bindings, and emits linker flags. None of that makes sense when the end result is "don't execute requests".

This PR replaces that with real stubs. With request execution disabled, all requests become no-ops, are optimized out by the compiler, and no build dependencies are pulled in.

**Breaking change**

This is breaking because Cargo features are additive-only. There is no way to disable optional dependencies by enabling a feature, so the old `opt-out` feature cannot be preserved.

Instead, `valgrind` is now the default feature, and stub mode is selected with `default-features = false`.

**Migration**

Before:
```toml
crabgrind = { ..., features = ["opt-out"] }
```

After:
```toml
crabgrind = { ..., default-features = false }
```

No code changes are required.

Planned for v0.3. 

FYI #10.